### PR TITLE
fix: ie11 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .vscode
 .DS_Store
 node_modules
+package-lock.json
+pnpm-lock.yaml
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ npm install --save virtual-select-plugin
 <link rel="stylesheet" href="node_modules/tooltip-plugin/dist/tooltip.min.css">
 <script src="node_modules/tooltip-plugin/dist/tooltip.min.js"></script>
 ```
+
+Particularly, to use under IE11, please check `examples/ie11compatible`.  

--- a/examples/ie11compatible/README.md
+++ b/examples/ie11compatible/README.md
@@ -1,0 +1,9 @@
+# IE11 compatible example
+
+In order to work under IE11, some polyfills are required
+1. [classList-toggle-force-polyfill](https://github.com/orangemug/classlist-toggle-force-polyfill). without this, "click on option" won't work 
+2. [custom-event-polyfill](https://github.com/kumarharsh/custom-event-polyfill). without this, IE11 will complain about "new Event": "Object doesn't support this action"
+3. [element-closest-polyfill](https://github.com/idmadj/element-closest-polyfill). without this, IE11 will fail on `closet` invoking.
+4. [core-js](https://github.com/zloirock/core-js). to polyfill some `es6` functions, like `Object.assign`.
+
+For the classList-toggle-force-polyfill, I didn't find an `unpkg` version, so slightly modified it and included here.  

--- a/examples/ie11compatible/classList-polyfill-ie9plus.js
+++ b/examples/ie11compatible/classList-polyfill-ie9plus.js
@@ -1,0 +1,77 @@
+var origToggle;
+
+// Has the polyfill been applied
+var fixed = false;
+
+/**
+ * The polyfill method
+ * @api private
+ */
+function method(val, force) {
+  var ret, el = this;
+
+  if(force === true) {
+    this.add(val);
+  } else if(force === false) {
+    this.remove(val);
+  } else {
+    return origToggle.call(this, val);
+  }
+  return this.contains(val);
+}
+
+
+/**
+ * Test if the fix is required
+ *
+ * @param {Boolean} initialValue if `true` was it initially required?
+ * @return {Boolean}
+ * @api public
+ */
+function required(initialValue) {
+  var ret, el;
+
+  // Was it initially required
+  if(initialValue && fixed)  {
+    return true;
+  }
+
+  // Don't try and polyfill if we're totally unsupported
+  if(typeof(window.DOMTokenList) === 'undefined') {
+    return false;
+  }
+
+  // The test element
+  el = document.createElement("div");
+
+  // Test force on. Add class first to test against normal toggle behaviour.
+  el.classList.add("t");
+  ret = el.classList.toggle("t", true);
+  if(ret !== true || !el.classList.contains("t")) {
+    return true;
+  }
+
+  // Test force off
+  ret = el.classList.toggle("o", false);
+  if (ret !== false || el.classList.contains("o")) {
+    return true;
+  }
+
+  return false;
+}
+
+
+/**
+ * Fix the toggle if required.
+ * @return {Function} method used in fix.
+ */
+function fix() {
+  if(required()) {
+    origToggle = DOMTokenList.prototype.toggle;
+    fixed = true;
+    DOMTokenList.prototype.toggle = method;
+    return method;
+  }
+}
+
+fix();

--- a/examples/ie11compatible/index.html
+++ b/examples/ie11compatible/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>vs demo</title>
+    <link rel="stylesheet" href="/dist/virtual-select.min.css">
+    <script type="application/javascript" src="classList-polyfill-ie9plus.js"></script>
+    <script type="application/javascript" src="https://unpkg.com/custom-event-polyfill@1.0.7/polyfill.js"></script>
+    <script type="application/javascript" src="https://unpkg.com/element-closest-polyfill@1.0.4/index.js"></script>
+    <script type="application/javascript" src="https://unpkg.com/core-js-bundle@3.20.2/minified.js"></script>
+    <script type="application/javascript" src="/dist/virtual-select.min.js"></script>
+</head>
+<body>
+<form>
+    <div id="sample-select1"></div>
+    <div id="sample-select2"></div>
+</form>
+<script>
+    var el1 = document.getElementById('sample-select1');
+    var el2 = document.getElementById('sample-select2');
+    var opts1 = [
+        {label: 'GP1 Options 1', value: '1'},
+        {label: 'GP1 Options 2', value: '2'},
+        {label: 'GP1 Options 3', value: '3'},
+    ];
+    var opts2 = [
+        {label: 'GP2 Options 1', value: '1'},
+        {label: 'GP2 Options 2', value: '2'},
+        {label: 'GP2 Options 3', value: '3'},
+    ];
+    VirtualSelect.init({
+        ele: [el1, el2],
+        multiple: true,
+        enableSecureText: true,
+        options: [],
+    });
+
+    el1.addEventListener('change', function (e) {
+        el2.setOptions(opts2)
+    });
+    setTimeout(function () {
+        el1.setOptions(opts1);
+    }, 1000)
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "docsify-cli": "^4.4.3",
     "filemanager-webpack-plugin": "^3.1.1",
     "mini-css-extract-plugin": "^0.11.3",
-    "node-sass": "^4.14.1",
+    "sass": "^1.45.2",
     "popover-plugin": "1.0.x",
     "sass-loader": "^10.1.1",
     "webpack": "^5.36.2",

--- a/src/utils/dom-utils.js
+++ b/src/utils/dom-utils.js
@@ -157,7 +157,7 @@ export class DomUtils {
     });
   }
 
-  static dispatchEvent($ele, eventName) {
+  static dispatchEvent($ele, eventName, bubbles = true) {
     if (!$ele) {
       return;
     }
@@ -167,7 +167,7 @@ export class DomUtils {
     /** using setTimeout to trigger asynchronous event */
     setTimeout(() => {
       $ele.forEach(($this) => {
-        $this.dispatchEvent(new Event(eventName, { bubbles: true }));
+        $this.dispatchEvent(new CustomEvent(eventName, { bubbles }));
       });
     }, 0);
   }

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -2364,7 +2364,7 @@ export class VirtualSelect {
     this.setValue(null, true);
     this.afterValueSet();
 
-    DomUtils.dispatchEvent(this.$ele, 'reset');
+    DomUtils.dispatchEvent(this.$ele, 'reset', false);
   }
 
   addOption(data, rerender) {


### PR DESCRIPTION
After several days searching and I found that only your `select` component meets my requirement:
1. virtual scroll
2. multiple select
3. search
4. supports event
5. vanllia js (not react/vue/ng)

there are some compability issues to fix under IE11.

for a minimal fix

1. A super simple example is added to show how to work under IE11, and some polyfills are includes.
2. `DomUtils.dispatchEvent` add a parameter: `bubbles`, default to `true`. To avoid `loop invokation` under IE11 after `reset` is dispatched.
3. `VirtualSelect.reset` will not dispatch a `reset event with bubbles`.
4. `node-sass` was replaced with `sass`, as `sass-loader` works with `sass` too. To install `node-sass`, `python2` and build environment are required, after hours of battling with the `node-sass` building, I gave up and chose `sass` which is easy to install. and the `scss` files building time didn't differs much.

------
Thanks for your awesome work.
J.R
