### PR TITLE
A11y fixed issues

### DIFF
--- a/src/sass/partials/virtual-select.scss
+++ b/src/sass/partials/virtual-select.scss
@@ -272,8 +272,8 @@
 }
 
 .vscomp-search-label,
-.vscomp-options-list-bottom,
-.vscomp-live-region {
+.vscomp-live-region,
+.vscomp-dropbox-container-bottom {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;

--- a/src/sass/partials/virtual-select.scss
+++ b/src/sass/partials/virtual-select.scss
@@ -272,6 +272,7 @@
 }
 
 .vscomp-search-label,
+.vscomp-options-bottom,
 .vscomp-live-region {
   border: 0;
   clip: rect(0 0 0 0);

--- a/src/sass/partials/virtual-select.scss
+++ b/src/sass/partials/virtual-select.scss
@@ -273,6 +273,7 @@
 
 .vscomp-search-label,
 .vscomp-live-region,
+.vscomp-dropbox-container-top,
 .vscomp-dropbox-container-bottom {
   border: 0;
   clip: rect(0 0 0 0);

--- a/src/sass/partials/virtual-select.scss
+++ b/src/sass/partials/virtual-select.scss
@@ -272,7 +272,7 @@
 }
 
 .vscomp-search-label,
-.vscomp-options-bottom,
+.vscomp-options-list-bottom,
 .vscomp-live-region {
   border: 0;
   clip: rect(0 0 0 0);

--- a/src/utils/dom-utils.js
+++ b/src/utils/dom-utils.js
@@ -217,7 +217,7 @@ export class DomUtils {
    * @static
    * @param {string} [$selector='']
    * @param {*} [$parentEle=undefined]
-   * @return {*} 
+   * @return {*}
    * @memberof DomUtils
    */
   static getElementsBySelector($selector = '', $parentEle = undefined) {

--- a/src/utils/dom-utils.js
+++ b/src/utils/dom-utils.js
@@ -214,6 +214,24 @@ export class DomUtils {
   }
 
   /**
+   * @static
+   * @param {string} [$selector='']
+   * @param {*} [$parentEle=undefined]
+   * @return {*} 
+   * @memberof DomUtils
+   */
+  static getElementsBySelector($selector = '', $parentEle = undefined) {
+    let elements;
+    const parent = $parentEle !== undefined ? $parentEle : document;
+
+    if ($selector !== '') {
+      elements = parent.querySelectorAll($selector);
+    }
+
+    return elements !== undefined ? Array.from(elements) : [];
+  }
+
+  /**
    * @param {HTMLElement} $ele
    * @param {string} events
    * @param {Function} callback

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -2346,14 +2346,19 @@ export class VirtualSelect {
   }
 
   focusFirstVisibleOption() {
-    const $focusableEle = this.$optionsContainer.querySelector(`[data-index='${this.getFirstVisibleOptionIndex()}']`);
-    if ($focusableEle !== undefined) {
+    let $focusableEle = this.$optionsContainer.querySelector(`[data-index='${this.getFirstVisibleOptionIndex()}']`);
+    if ($focusableEle) {
       DomUtils.setAttr($focusableEle, 'tabindex', '0');
       this.$optionsContainer.scrollTop = this.optionHeight * this.getFirstVisibleOptionIndex();
       this.focusOption({
         focusFirst: true,
       });
       $focusableEle.focus();
+    } else {
+      $focusableEle = this.$dropbox.querySelector('[tabindex="0"]');
+      if ($focusableEle) {
+        $focusableEle.focus();
+      }
     }
   }
 

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -2349,7 +2349,7 @@ export class VirtualSelect {
     let $focusableEle = this.$optionsContainer.querySelector(`[data-index='${this.getFirstVisibleOptionIndex()}']`);
 
     if ($focusableEle) {
-      if (DomUtils.hasClass($focusableEle, '.group-title')) {
+      if (DomUtils.hasClass($focusableEle, 'group-title')) {
         $focusableEle = this.getSibling($focusableEle, 'next');
       }
 

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -285,6 +285,7 @@ export class VirtualSelect {
       let rightSection = '';
       let description = '';
       let groupIndexText = '';
+      let ariaLabel = '';
       const isSelected = convertToBoolean(d.isSelected);
       let ariaDisabledText = '';
 
@@ -316,6 +317,10 @@ export class VirtualSelect {
       if (d.isGroupOption) {
         optionClasses += ' group-option';
         groupIndexText = `data-group-index="${d.groupIndex}"`;
+
+        const groupName = d.customData.group_name !== undefined ? `${d.customData.group_name}, ` : '';
+        const optionDesc = d.customData.description !== undefined ? ` ${d.customData.description},` : '';
+        ariaLabel = `aria-label="${groupName}${d.label},${optionDesc}"`;
       }
 
       if (hasLabelRenderer) {
@@ -337,7 +342,7 @@ export class VirtualSelect {
 
       html += `<div role="option" aria-selected="${isSelected}" id="vscomp-option-${uniqueId}-${index}"
           class="${optionClasses}" data-value="${d.value}" data-index="${index}" data-visible-index="${d.visibleIndex}"
-          tabindex="0" ${groupIndexText} ${ariaDisabledText}
+          tabindex="0" ${groupIndexText} ${ariaDisabledText} ${ariaLabel}
         >
           ${leftSection}
           <span class="vscomp-option-text" ${optionTooltip}>

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -204,6 +204,7 @@ export class VirtualSelect {
     this.$search = this.$dropboxContainer.querySelector('.vscomp-search-wrapper');
     this.$optionsContainer = this.$dropboxContainer.querySelector('.vscomp-options-container');
     this.$optionsList = this.$dropboxContainer.querySelector('.vscomp-options-list');
+    this.$optionsListBottom = this.$dropboxContainer.querySelector('.vscomp-bottom-item');
     this.$options = this.$dropboxContainer.querySelector('.vscomp-options');
     this.$noOptions = this.$dropboxContainer.querySelector('.vscomp-no-options');
     this.$noSearchResults = this.$dropboxContainer.querySelector('.vscomp-no-search-results');
@@ -223,6 +224,7 @@ export class VirtualSelect {
 
             <div class="vscomp-options-list">
               <div class="vscomp-options"></div>
+              <div class="vscomp-options-bottom" tabindex=0></div>
             </div>
           </div>
 
@@ -286,6 +288,7 @@ export class VirtualSelect {
       let description = '';
       let groupIndexText = '';
       let ariaLabel = '';
+      let tabIndexValue = '0';
       const isSelected = convertToBoolean(d.isSelected);
       let ariaDisabledText = '';
 
@@ -303,6 +306,7 @@ export class VirtualSelect {
       }
 
       if (d.isGroupTitle) {
+        tabIndexValue = '-1';
         optionClasses += ' group-title';
 
         if (disableOptionGroupCheckbox) {
@@ -342,7 +346,7 @@ export class VirtualSelect {
 
       html += `<div role="option" aria-selected="${isSelected}" id="vscomp-option-${uniqueId}-${index}"
           class="${optionClasses}" data-value="${d.value}" data-index="${index}" data-visible-index="${d.visibleIndex}"
-          tabindex="0" ${groupIndexText} ${ariaDisabledText} ${ariaLabel}
+          tabindex=${tabIndexValue} ${groupIndexText} ${ariaDisabledText} ${ariaLabel}
         >
           ${leftSection}
           <span class="vscomp-option-text" ${optionTooltip}>
@@ -399,6 +403,7 @@ export class VirtualSelect {
     this.addEvent(this.$searchInput, 'input', 'onSearch');
     this.addEvent(this.$searchClear, 'click', 'onSearchClear');
     this.addEvent(this.$toggleAllButton, 'click', 'onToggleAllOptions');
+    this.addEvent(this.$optionsListBottom, 'focus', 'onFocusBottom');
   }
   /** render methods - end */
 
@@ -449,7 +454,8 @@ export class VirtualSelect {
     const key = e.which || e.keyCode;
     const method = keyDownMethodMapping[key];
 
-    if (document.activeElement === this.$searchInput && (key === 9 || (e.shiftKey && key === 9))) {
+    // if (document.activeElement === this.$searchInput && (key === 9 || (e.shiftKey && key === 9))) {
+    if (document.activeElement === this.$searchInput && (e.shiftKey && key === 9)) {
       this.closeDropbox();
       return;
     }
@@ -494,9 +500,11 @@ export class VirtualSelect {
   }
 
   onBackspaceOrDeletePress(e) {
-    e.preventDefault();
-    if (this.selectedValues.length > 0) {
-      this.reset();
+    if (e.target === this.$wrapper) {
+      e.preventDefault();
+      if (this.selectedValues.length > 0) {
+        this.reset();
+      }
     }
   }
 
@@ -579,6 +587,10 @@ export class VirtualSelect {
 
   onToggleAllOptions() {
     this.toggleAllOptions();
+  }
+
+  onFocusBottom() {
+    this.closeDropbox();
   }
 
   onResize() {
@@ -688,9 +700,11 @@ export class VirtualSelect {
     this.setOptionsPosition();
     this.setOptionsTooltip();
 
-    const focusedOption = DomUtils.getElementsBySelector('.focused', this.$dropboxContainer)[0];
-    if (focusedOption !== undefined) {
-      focusedOption.focus();
+    if (document.activeElement !== this.$searchInput) {
+      const focusedOption = DomUtils.getElementsBySelector('.focused', this.$dropboxContainer)[0];
+      if (focusedOption !== undefined) {
+        focusedOption.focus();
+      }
     }
   }
 
@@ -2982,7 +2996,9 @@ export class VirtualSelect {
       return;
     }
 
-    $ele.focus();
+    if (document.activeElement !== this.$searchInput) {
+      $ele.focus();
+    }
     DomUtils.toggleClass($ele, 'focused', isFocused);
 
     if (isFocused) {

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -261,6 +261,7 @@ export class VirtualSelect {
     const visibleOptions = this.getVisibleOptions();
     let checkboxHtml = '';
     let newOptionIconHtml = '';
+    let focusedOption = [];
     const markSearchResults = !!(this.markSearchResults && this.searchValue);
     let searchRegex;
     const { labelRenderer, disableOptionGroupCheckbox, uniqueId, searchGroup } = this;
@@ -679,6 +680,11 @@ export class VirtualSelect {
     this.setOptionAttr();
     this.setOptionsPosition();
     this.setOptionsTooltip();
+
+    const focusedOption = DomUtils.getElementsBySelector('.focused', this.$dropboxContainer)[0];
+    if (focusedOption !== undefined) {
+      focusedOption.focus();
+    }
   }
 
   afterSetOptionsContainerHeight(reset) {
@@ -2973,6 +2979,7 @@ export class VirtualSelect {
       return;
     }
 
+    $ele.focus();
     DomUtils.toggleClass($ele, 'focused', isFocused);
 
     if (isFocused) {

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -403,7 +403,7 @@ export class VirtualSelect {
     this.addEvent(this.$searchInput, 'input', 'onSearch');
     this.addEvent(this.$searchClear, 'click', 'onSearchClear');
     this.addEvent(this.$toggleAllButton, 'click', 'onToggleAllOptions');
-    this.addEvent(this.$optionsListBottom, 'focus', 'onFocusBottom');
+    this.addEvent(this.$optionsListBottom, 'focus', 'onOptionsListBottomFocus');
   }
   /** render methods - end */
 
@@ -589,7 +589,7 @@ export class VirtualSelect {
     this.toggleAllOptions();
   }
 
-  onFocusBottom() {
+  onOptionsListBottomFocus() {
     this.closeDropbox();
   }
 

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -467,7 +467,7 @@ export class VirtualSelect {
 
     if (this.isOpened()) {
       this.selectFocusedOption();
-    } else {
+    } else if (this.$ele.disabled === false) {
       this.openDropbox();
     }
   }
@@ -2882,6 +2882,7 @@ export class VirtualSelect {
     this.$ele.removeAttribute('disabled');
     this.$hiddenInput.removeAttribute('disabled');
     DomUtils.setAria(this.$wrapper, 'disabled', false);
+    DomUtils.changeTabIndex(this.$wrapper, 0);
   }
 
   disable() {
@@ -2890,6 +2891,8 @@ export class VirtualSelect {
     this.$ele.setAttribute('disabled', '');
     this.$hiddenInput.setAttribute('disabled', '');
     DomUtils.setAria(this.$wrapper, 'disabled', true);
+    DomUtils.changeTabIndex(this.$wrapper, -1);
+    this.$wrapper.blur();
   }
 
   validate() {

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -201,10 +201,10 @@ export class VirtualSelect {
     this.$hiddenInput = this.$ele.querySelector('.vscomp-hidden-input');
     this.$dropbox = this.$dropboxContainer.querySelector('.vscomp-dropbox');
     this.$dropboxCloseButton = this.$dropboxContainer.querySelector('.vscomp-dropbox-close-button');
+    this.$dropboxContainerBottom = this.$dropboxContainer.querySelector('.vscomp-dropbox-container-bottom');
     this.$search = this.$dropboxContainer.querySelector('.vscomp-search-wrapper');
     this.$optionsContainer = this.$dropboxContainer.querySelector('.vscomp-options-container');
     this.$optionsList = this.$dropboxContainer.querySelector('.vscomp-options-list');
-    this.$optionsListBottom = this.$dropboxContainer.querySelector('.vscomp-options-list-bottom');
     this.$options = this.$dropboxContainer.querySelector('.vscomp-options');
     this.$noOptions = this.$dropboxContainer.querySelector('.vscomp-no-options');
     this.$noSearchResults = this.$dropboxContainer.querySelector('.vscomp-no-search-results');
@@ -224,7 +224,6 @@ export class VirtualSelect {
 
             <div class="vscomp-options-list">
               <div class="vscomp-options"></div>
-              <div class="vscomp-options-list-bottom" aria-hidden="true" tabindex="0">&nbsp;</div>
             </div>
           </div>
 
@@ -234,6 +233,7 @@ export class VirtualSelect {
 
           <span class="vscomp-dropbox-close-button"><i class="vscomp-clear-icon"></i></span>
         </div>
+        <div class="vscomp-dropbox-container-bottom" aria-hidden="true" tabindex="0">&nbsp;</div>
       </div>
 `;
 
@@ -403,7 +403,7 @@ export class VirtualSelect {
     this.addEvent(this.$searchInput, 'input', 'onSearch');
     this.addEvent(this.$searchClear, 'click', 'onSearchClear');
     this.addEvent(this.$toggleAllButton, 'click', 'onToggleAllOptions');
-    this.addEvent(this.$optionsListBottom, 'focus', 'onOptionsListBottomFocus');
+    this.addEvent(this.$dropboxContainerBottom, 'focus', 'onDropboxContainerBottomFocus');
   }
   /** render methods - end */
 
@@ -589,7 +589,7 @@ export class VirtualSelect {
     this.toggleAllOptions();
   }
 
-  onOptionsListBottomFocus() {
+  onDropboxContainerBottomFocus() {
     this.closeDropbox();
   }
 
@@ -692,9 +692,23 @@ export class VirtualSelect {
 
     if (!this.allowNewOption || this.hasServerSearch || this.showOptionsOnlyOnSearch) {
       DomUtils.toggleClass(this.$allWrappers, 'has-no-search-results', hasNoSearchResults);
+      if (hasNoSearchResults) {
+        DomUtils.setAttr(this.$noSearchResults, 'tabindex', '0');
+        DomUtils.setAttr(this.$noSearchResults, 'aria-hidden', 'false');
+      } else {
+        DomUtils.setAttr(this.$noSearchResults, 'tabindex', '-1');
+        DomUtils.setAttr(this.$noSearchResults, 'aria-hidden', 'true');
+      }
     }
 
     DomUtils.toggleClass(this.$allWrappers, 'has-no-options', hasNoOptions);
+    if (hasNoOptions) {
+      DomUtils.setAttr(this.$noOptions, 'tabindex', '0');
+      DomUtils.setAttr(this.$noOptions, 'aria-hidden', 'false');
+    } else {
+      DomUtils.setAttr(this.$noOptions, 'tabindex', '-1');
+      DomUtils.setAttr(this.$noOptions, 'aria-hidden', 'true');
+    }
 
     this.setOptionAttr();
     this.setOptionsPosition();
@@ -2292,9 +2306,15 @@ export class VirtualSelect {
 
   focusSearchInput() {
     const $ele = this.$searchInput;
+    const hasNoOptions = !this.options.length && !this.hasServerSearch;
 
     if ($ele) {
-      $ele.focus();
+      if (hasNoOptions) {
+        DomUtils.setAttr($ele, 'disabled', '');
+        this.$noOptions.focus();
+      } else {
+        $ele.focus();
+      }
     }
   }
 

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -2347,7 +2347,12 @@ export class VirtualSelect {
 
   focusFirstVisibleOption() {
     let $focusableEle = this.$optionsContainer.querySelector(`[data-index='${this.getFirstVisibleOptionIndex()}']`);
+
     if ($focusableEle) {
+      if (DomUtils.hasClass($focusableEle, '.group-title')) {
+        $focusableEle = this.getSibling($focusableEle, 'next');
+      }
+
       DomUtils.setAttr($focusableEle, 'tabindex', '0');
       this.$optionsContainer.scrollTop = this.optionHeight * this.getFirstVisibleOptionIndex();
       this.focusOption({

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -10,6 +10,8 @@ const keyDownMethodMapping = {
   13: 'onEnterPress',
   38: 'onUpArrowPress',
   40: 'onDownArrowPress',
+  46: 'onBackspaceOrDeletePress', // Delete
+  8: 'onBackspaceOrDeletePress', // Backspace
 };
 
 const valueLessProps = ['autofocus', 'disabled', 'multiple', 'required'];
@@ -175,7 +177,6 @@ export class VirtualSelect {
           <div class="vscomp-clear-button toggle-button-child" ${clearButtonTooltip}>
             <i class="vscomp-clear-icon"></i>
           </div>
-        </div>
 
         ${this.renderDropbox({ wrapperClasses })}
       </div>`;
@@ -484,6 +485,13 @@ export class VirtualSelect {
       this.focusOption({ direction: 'previous' });
     } else {
       this.openDropbox();
+    }
+  }
+
+  onBackspaceOrDeletePress(e) {
+    e.preventDefault();
+    if (this.selectedValues.length > 0) {
+      this.reset();
     }
   }
 

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -177,17 +177,12 @@ export class VirtualSelect {
           </div>
         </div>
 
-        <section role="region" class="vscomp-live-region" aria-live="polite">
-          <p class="vscomp-live-region-title"></p>
-        </section>
-
         ${this.renderDropbox({ wrapperClasses })}
       </div>`;
 
     this.$ele.innerHTML = html;
     this.$body = document.querySelector('body');
     this.$wrapper = this.$ele.querySelector('.vscomp-wrapper');
-    this.$ariaLiveElem = this.$ele.querySelector('.vscomp-live-region-title');
 
     if (this.hasDropboxWrapper) {
       this.$allWrappers = [this.$wrapper, this.$dropboxWrapper];
@@ -261,7 +256,6 @@ export class VirtualSelect {
     const visibleOptions = this.getVisibleOptions();
     let checkboxHtml = '';
     let newOptionIconHtml = '';
-    let focusedOption = [];
     const markSearchResults = !!(this.markSearchResults && this.searchValue);
     let searchRegex;
     const { labelRenderer, disableOptionGroupCheckbox, uniqueId, searchGroup } = this;
@@ -2300,10 +2294,6 @@ export class VirtualSelect {
     if ($newFocusedEle && $newFocusedEle !== $focusedEle) {
       if ($focusedEle) {
         this.toggleOptionFocusedState($focusedEle, false);
-      }
-
-      if (this.$ariaLiveElem) {
-        this.$ariaLiveElem.textContent = $newFocusedEle.textContent;
       }
 
       this.toggleOptionFocusedState($newFocusedEle, true);

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -204,7 +204,7 @@ export class VirtualSelect {
     this.$search = this.$dropboxContainer.querySelector('.vscomp-search-wrapper');
     this.$optionsContainer = this.$dropboxContainer.querySelector('.vscomp-options-container');
     this.$optionsList = this.$dropboxContainer.querySelector('.vscomp-options-list');
-    this.$optionsListBottom = this.$dropboxContainer.querySelector('.vscomp-bottom-item');
+    this.$optionsListBottom = this.$dropboxContainer.querySelector('.vscomp-options-list-bottom');
     this.$options = this.$dropboxContainer.querySelector('.vscomp-options');
     this.$noOptions = this.$dropboxContainer.querySelector('.vscomp-no-options');
     this.$noSearchResults = this.$dropboxContainer.querySelector('.vscomp-no-search-results');
@@ -224,7 +224,7 @@ export class VirtualSelect {
 
             <div class="vscomp-options-list">
               <div class="vscomp-options"></div>
-              <div class="vscomp-options-bottom" tabindex=0></div>
+              <div class="vscomp-options-list-bottom" aria-hidden="true" tabindex="0">&nbsp;</div>
             </div>
           </div>
 


### PR DESCRIPTION
This PR will add several improvements for accessibility, such:
- Fixed the disabled behaviour since when a keyboard was in use to navigate though the screen it was possible to open a disabled dropdown;
- Improved the options structure in order to proper reflect the correct information about each one by changing the way focus was being managed;
- Disabled tabindex=0 at all options and set it only to the one that is focused;
- Removed live-region, once managing/update focus it will not be needed;
- aria-label was added to all the options;
- Disabled search input focus when there is no options to show;
- Added the ability to clear all the selected options when user uses the backspace or delete key;