### PR TITLE
Fix issue with selectAllOnlyVisible and empty filtered list

### DIFF
--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -2544,8 +2544,10 @@ export class VirtualSelect {
       isAllSelected = this.isAllOptionsSelected();
     }
 
-    /** when all options not selected, checking if all visible options selected */
-    if (!isAllSelected && this.selectAllOnlyVisible) {
+    /** when all options not selected, checking if all visible options selected 
+     *  Also, in a search mode, validate that we still have visible items
+    */
+    if (!isAllSelected && this.selectAllOnlyVisible  && (this.searchValue !== '' && this.visibleOptionsCount > 0 || this.searchValue == '')) {
       isAllVisibleSelected = this.isAllOptionsSelected(true);
     }
 


### PR DESCRIPTION
This PR aims to fix an issue with `selectAllOnlyVisible:true` and empty filtered lists.

### What was happening

- When using  `selectAllOnlyVisible:true` having multiple selection and search
    - options like these: 
![image](https://github.com/sa-si-dev/virtual-select/assets/29493222/59e0d654-9163-4515-8466-a20fdc19216a)
- Selected one option
- Filtered by an unexisting word 
- The list is empty but the select all checkbox was being checked - ❌
![selectAllOnlyVisible_EmptySearchIssue](https://github.com/sa-si-dev/virtual-select/assets/29493222/2cf2e5a7-1c46-4fb9-a97a-c65b79f9295b)

  
### After the fix
- Followed the same steps above - ✅
- Ran regression scenarios - ✅
- Run automated tests - ✅

![image](https://github.com/sa-si-dev/virtual-select/assets/29493222/39001727-c74e-4627-9c1d-bf97ed18679c)



It is now working as expected:

![selectAllOnlyVisible_EmptySearchIssueFix](https://github.com/sa-si-dev/virtual-select/assets/29493222/f3a1fcd3-8ff7-4cb4-9520-bde27f709966)



