### PR TITLE
Fix search feature unresponsive after setting an empty list

### DIFF
--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -2401,6 +2401,7 @@ export class VirtualSelect {
         DomUtils.setAttr($ele, 'disabled', '');
         this.$noOptions.focus();
       } else {
+        $ele.removeAttribute('disabled');
         $ele.focus();
       }
     } else {


### PR DESCRIPTION
- This PR aims to fix the issue #318 
- When using dropdown with the search feature on, the search feature became unresponsive after setting an empty options list.

### What was happening

- To replicate it:
    1. Open the dropdown and click on the Search input
    2. Checked we can type there and sort the list
    3. Click on `Remove All`
    4. Open the dropdown and click on the Search input 
    5. Checked that it is disabled as expected since the options list has no options
    6. Click on `Fill`
    7. Open the dropdown and click on the Search input 
    8. Checked that it is incorrectly disabled 

![#318_Issue](https://github.com/sa-si-dev/virtual-select/assets/29493222/4e46cc2a-dde1-444d-88e3-7c1b99b3d420)


### After the fix
- The fix was on the method `focusElementOnOpen()`
- To replicate it:
    1. Open the dropdown and click on the Search input
    2. Checked we can type there and sort the list
    3. Click on `Remove All`
    4. Open the dropdown and click on the Search input 
    5. Checked that it is disabled as expected since the options list has no options
    6. Click on `Fill`
    7. Open the dropdown and click on the Search input 
    8. Checked we can type there and sort the list

![#318_Fixed](https://github.com/sa-si-dev/virtual-select/assets/29493222/7d59129b-defe-4f79-b4de-9125f420c386)


- Followed the same steps above - ✅
- Ran regression scenarios - ✅
- Run automated tests - ✅

![image](https://github.com/sa-si-dev/virtual-select/assets/29493222/4d9a683c-7ac5-4054-84b7-24f1ce122643)



