### PR TITLE
Mitigate issue with translate3D in Chromium-based browsers

### DIFF
--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -1481,7 +1481,7 @@ export class VirtualSelect {
   }
 
   setOptionsPosition(startIndex) {
-    const top = (startIndex || this.getVisibleStartIndex()) * this.optionHeight;
+    const top = parseInt((startIndex || this.getVisibleStartIndex()) * this.optionHeight);
     this.$options.style.transform = `translate3d(0, ${top}px, 0)`;
     DomUtils.setData(this.$options, 'top', top);
   }


### PR DESCRIPTION
### What was happening

- In Chromium-based browsers under specific window sizes/resolutions, the dropdowns can have their content blurry:

![image](https://github.com/sa-si-dev/virtual-select/assets/29493222/43a1fb85-4584-4609-ae59-abf3d85fab71)


### After the fix

- Added a parseInt to `setOptionsPosition()` to help fixing the issue with translate3D.

- Ran regression scenarios - ✅
- Run automated tests - ✅

![image](https://github.com/sa-si-dev/virtual-select/assets/29493222/3bf70e27-c54a-4524-8941-dfcc3bc890fb)

