### PR TITLE
Fix XSS vulnerability in VirtualSelect

### DIFF
--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -3155,7 +3155,7 @@ export class VirtualSelect {
 
     this.$secureText.nodeValue = text;
 
-    return this.$secureDiv.innerHTML;
+    return Utils.replaceDoubleQuotesWithHTML(this.$secureDiv.innerHTML);
   }
 
   toggleRequired(isRequired) {


### PR DESCRIPTION
Fixes #365

Update the `secureText` method in `src/virtual-select.js` to enhance XSS protection.

* Modify the return statement to use `Utils.replaceDoubleQuotesWithHTML(this.$secureDiv.innerHTML)` instead of `this.$secureDiv.innerHTML`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sa-si-dev/virtual-select/pull/366?shareId=d79158b2-30c2-4375-9e64-07de814aec47).