### PR TITLE
Avoid setSearchValue executing when the value didn't change

### DIFF
--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -1742,6 +1742,12 @@ export class VirtualSelect {
     }
 
     const searchValue = value.replace(/\\/g, '').toLowerCase().trim();
+
+    // Only proceed if the search value actually changed
+    if (searchValue === this.searchValue && !forceSet) {
+      return;
+    }
+
     this.searchValue = searchValue;
     this.searchValueOriginal = value;
 


### PR DESCRIPTION
#### What was done
- This PR aims to fix #293, where the `change` event was fired twice when the end user searched a value before selecting it.


#### Validations
- Ran regression scenarios - 
- Run automated tests - 

