### PR TITLE
Entrance animation issue when openDropbox is triggered programatically

### DIFF
--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -2347,7 +2347,7 @@ export class VirtualSelect {
 
   openDropbox(isSilent) {
     // Store original transition
-    const originalTransition = this.$dropboxContainer.style.transition;
+    const originalTransition = "";
     // Disable transitions for programmatic opening
     if (!isSilent) {
       this.$dropboxContainer.style.transition = 'none';

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -2346,6 +2346,13 @@ export class VirtualSelect {
   }
 
   openDropbox(isSilent) {
+    // Store original transition
+    const originalTransition = this.$dropboxContainer.style.transition;
+    // Disable transitions for programmatic opening
+    if (!isSilent) {
+      this.$dropboxContainer.style.transition = 'none';
+    }
+    // Perform the open operation
     this.isSilentOpen = isSilent;
 
     DomUtils.setAttr(this.$dropboxWrapper, 'tabindex', '0');
@@ -2365,9 +2372,16 @@ export class VirtualSelect {
     }
 
     this.setDropboxWrapperWidth();
-
     DomUtils.removeClass(this.$allWrappers, 'closed');
     DomUtils.changeTabIndex(this.$allWrappers, 0);
+
+    if (!isSilent) {
+      // Force synchronous layout and style calculation
+      // Trigger reflow
+      this.$dropboxContainer.offsetHeight; // eslint-disable-line no-unused-expressions
+      // Restore transitions immediately after reflow
+      this.$dropboxContainer.style.transition = originalTransition;
+    }
 
     if (this.dropboxPopover && !isSilent) {
       this.dropboxPopover.show();

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -2346,10 +2346,10 @@ export class VirtualSelect {
   }
 
   openDropbox(isSilent) {
-    // Store original transition
-    const originalTransition = "";
+    let originalTransition = '';
     // Disable transitions for programmatic opening
     if (!isSilent) {
+      // Store original transition
       originalTransition = this.$dropboxContainer.style.transition;
       this.$dropboxContainer.style.transition = 'none';
     }

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -2350,6 +2350,7 @@ export class VirtualSelect {
     const originalTransition = "";
     // Disable transitions for programmatic opening
     if (!isSilent) {
+      originalTransition = this.$dropboxContainer.style.transition;
       this.$dropboxContainer.style.transition = 'none';
     }
     // Perform the open operation


### PR DESCRIPTION
#### What was done
- This PR aims to fix #244, where the dropbox entrance animation looked clunky when opened, calling `openDropbox` programmatically as illustrated in the issue that was opened:

![02e2a0b3-ce97-401c-9acc-c8d217331bd0](https://user-images.githubusercontent.com/5339917/231416503-ac76519f-413b-4a53-8cc9-24968d03a9a0.gif)


#### Validations
- Ran regression scenarios - ✅
- Run automated tests - ✅
 
![image](https://github.com/user-attachments/assets/d305d208-09f4-496d-a9ba-d9bc351e09c1)

