### PR TITLE
Fix issue when pressing ESC under certain configurations

### DIFF
--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -547,7 +547,11 @@ export class VirtualSelect {
     // Handle the Escape key when showing the dropdown as a popup, closing it
     if (key === 27 || e.key === 'Escape') {
       const wrapper = this.showAsPopup ? this.$wrapper : this.$dropboxWrapper;
-      if ((document.activeElement === wrapper || wrapper.contains(document.activeElement)) && !this.keepAlwaysOpen) {
+      if (
+        wrapper &&
+        (document.activeElement === wrapper || wrapper.contains(document.activeElement)) &&
+        !this.keepAlwaysOpen
+      ) {
         this.closeDropbox();
         return;
       }


### PR DESCRIPTION
#### What was done
- This PR aims to fix #404, where pressing ESC under certain configurations (like `keepAlwaysOpen=true`) was throwing the following error:

```markdown
Uncaught TypeError: Cannot read properties of undefined (reading 'contains') 
   at VirtualSelect.onKeyDown
``` 


#### Validations
- Ran regression scenarios - ✅
- Run automated tests - ✅
 
![image](https://github.com/user-attachments/assets/f937d7a5-cea7-4cce-b3eb-f0390b9d7e6e)


