### PR TITLE
Fix issue when using booleans as dropdown options

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -59,6 +59,40 @@ export class Utils {
   }
 
   /**
+   * Normalizes values by converting booleans to strings while preserving other types
+   * Handles both single values and arrays efficiently
+   * @param {*} value - The value to normalize
+   * @return {*} - Normalized value(s)
+   * @memberof Utils
+   */
+  static normalizeValues(value) {
+    // Fast path for arrays
+    if (Array.isArray(value)) {
+      const result = new Array(value.length);
+      for (let i = 0; i < value.length; i += 1) {
+        const v = value[i];
+        if (v === true) {
+          result[i] = 'true';
+        } else if (v === false) {
+          result[i] = 'false';
+        } else {
+          result[i] = v;
+        }
+      }
+      return result;
+    }
+
+    // Handle single values
+    if (value === true) {
+      return 'true';
+    }
+    if (value === false) {
+      return 'false';
+    }
+    return value;
+  }
+
+  /**
    * @param {any[]} array
    * @param {any} value
    * @param {boolean} cloneArray

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -1751,12 +1751,6 @@ export class VirtualSelect {
     }
 
     const searchValue = value.replace(/\\/g, '').toLowerCase().trim();
-
-    // Only proceed if the search value actually changed
-    if (searchValue === this.searchValue && !forceSet) {
-      return;
-    }
-
     this.searchValue = searchValue;
     this.searchValueOriginal = value;
 

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -1134,7 +1134,8 @@ export class VirtualSelect {
     const valuesOrder = {};
     let validValues = [];
     const isMultiSelect = this.multiple;
-    let value = newValue;
+    // Normalize input value first
+    let value = Utils.normalizeValues(newValue);
 
     if (value) {
       if (!Array.isArray(value)) {
@@ -1151,9 +1152,6 @@ export class VirtualSelect {
         value = [value[0]];
       }
 
-      /** converting value to string */
-      value = value.map((v) => (v || v === 0 ? v.toString() : ''));
-
       if (this.useGroupValue) {
         value = this.setGroupOptionsValue(value);
       }
@@ -1169,9 +1167,12 @@ export class VirtualSelect {
     }
 
     this.options.forEach((d) => {
-      if (valuesMapping[d.value] === true && !d.isDisabled && !d.isGroupTitle) {
+      // Compare with normalized option values
+      const normalizedOptionValue = Utils.normalizeValues(d.value);
+      if (valuesMapping[normalizedOptionValue] === true && !d.isDisabled && !d.isGroupTitle) {
         // eslint-disable-next-line no-param-reassign
         d.isSelected = true;
+        // Store original value but compare with normalized value
         validValues.push(d.value);
       } else {
         // eslint-disable-next-line no-param-reassign
@@ -1185,7 +1186,7 @@ export class VirtualSelect {
       }
 
       /** sorting validValues in the given values order */
-      validValues.sort((a, b) => valuesOrder[a] - valuesOrder[b]);
+      validValues.sort((a, b) => valuesOrder[Utils.normalizeValues(a)] - valuesOrder[Utils.normalizeValues(b)]);
     } else {
       /** taking first value for single select */
       [validValues] = validValues;
@@ -1564,14 +1565,16 @@ export class VirtualSelect {
   }
 
   setValue(value, { disableEvent = false, disableValidation = false } = {}) {
-    const isValidValue = (this.hasEmptyValueOption && value === '') || value;
+    // Normalize input value first
+    const normalizedValue = Utils.normalizeValues(value);
+    const isValidValue = (this.hasEmptyValueOption && normalizedValue === '') || normalizedValue;
 
     if (!isValidValue) {
       this.selectedValues = [];
-    } else if (Array.isArray(value)) {
-      this.selectedValues = [...value];
+    } else if (Array.isArray(normalizedValue)) {
+      this.selectedValues = [...normalizedValue];
     } else {
-      this.selectedValues = [value];
+      this.selectedValues = [normalizedValue];
     }
 
     const newValue = this.getValue();
@@ -2039,16 +2042,12 @@ export class VirtualSelect {
     let value;
 
     if (this.multiple) {
-      if (this.useGroupValue) {
-        value = this.getGroupValue();
-      } else {
-        value = this.selectedValues;
-      }
+      value = this.useGroupValue ? this.getGroupValue() : this.selectedValues;
     } else {
       value = this.selectedValues[0] || '';
     }
 
-    return value;
+    return Utils.normalizeValues(value);
   }
 
   getGroupValue() {

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -1742,6 +1742,12 @@ export class VirtualSelect {
     }
 
     const searchValue = value.replace(/\\/g, '').toLowerCase().trim();
+
+    // Only proceed if the search value actually changed
+    if (searchValue === this.searchValue && !forceSet) {
+      return;
+    }
+
     this.searchValue = searchValue;
     this.searchValueOriginal = value;
 


### PR DESCRIPTION
#### What was done
- This PR aims to fix #388, where using booleans as dropdown options (values) made the following values be returned:
    - If selected `true`, returned `true` as expected 
    - If selected `false`, returned **incorrectly** an empty value `""`

#### Validations
- Ran regression scenarios in the documentation using the branch - ✅
- Ran additional tests at https://codepen.io/gmar/pen/OPPZbVZ - ✅
- Run automated tests - ✅
 
![image](https://github.com/user-attachments/assets/b55c1b2f-676b-486a-840f-8d4e5dc328b6)
