### PR TITLE
Fix error thrown when adding a new option and searchNormalize enabled

### DIFF
--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -3081,9 +3081,9 @@ export class VirtualSelect {
 
   isOptionVisible({ data, searchValue, hasExactOption, visibleOptionGroupsMapping, searchGroup, searchByStartsWith }) {
     const value = data.value.toLowerCase();
-    const label = this.searchNormalize && data.label.trim()
-      ? data.labelNormalized || data.label.toLowerCase()
-      : data.label.toLowerCase();
+    const label = this.searchNormalize && data.labelNormalized
+      ? data.labelNormalized 
+      : data.label.trim().toLowerCase();
     const { description, alias } = data;
 
     let isVisible = searchByStartsWith ? label.startsWith(searchValue) : label.includes(searchValue);

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -1376,7 +1376,9 @@ export class VirtualSelect {
         index,
         value,
         label,
-        labelNormalized: this.searchNormalize ? Utils.normalizeString(label).toLowerCase() : label.toLowerCase(),
+        labelNormalized: this.searchNormalize && label.trim()
+          ? Utils.normalizeString(label).toLowerCase()
+          : label.toLowerCase(),
         alias: getAlias(d[aliasKey]),
         isVisible: convertToBoolean(d.isVisible, true),
         isNew: d.isNew || false,
@@ -1770,7 +1772,9 @@ export class VirtualSelect {
 
     /** If searchNormalize we'll normalize the searchValue */
     let { searchValue } = this;
-    searchValue = this.searchNormalize ? Utils.normalizeString(searchValue) : searchValue;
+    searchValue = this.searchNormalize && searchValue.trim()
+      ? Utils.normalizeString(searchValue)
+      : searchValue;
     const isOptionVisible = this.isOptionVisible.bind(this);
 
     if (this.hasOptionGroup) {
@@ -3077,7 +3081,9 @@ export class VirtualSelect {
 
   isOptionVisible({ data, searchValue, hasExactOption, visibleOptionGroupsMapping, searchGroup, searchByStartsWith }) {
     const value = data.value.toLowerCase();
-    const label = this.searchNormalize ? data.labelNormalized : data.label.toLowerCase();
+    const label = this.searchNormalize && data.label.trim()
+      ? data.labelNormalized || data.label.toLowerCase()
+      : data.label.toLowerCase();
     const { description, alias } = data;
 
     let isVisible = searchByStartsWith ? label.startsWith(searchValue) : label.includes(searchValue);

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -3082,7 +3082,7 @@ export class VirtualSelect {
   isOptionVisible({ data, searchValue, hasExactOption, visibleOptionGroupsMapping, searchGroup, searchByStartsWith }) {
     const value = data.value.toLowerCase();
     const label = this.searchNormalize && data.labelNormalized !== undefined
-      ? data.labelNormalized 
+      ? data.labelNormalized
       : data.label.trim().toLowerCase();
     const { description, alias } = data;
 

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -1376,7 +1376,7 @@ export class VirtualSelect {
         index,
         value,
         label,
-        labelNormalized: this.searchNormalize && label.trim()
+        labelNormalized: this.searchNormalize && label.trim() !== ''
           ? Utils.normalizeString(label).toLowerCase()
           : label.toLowerCase(),
         alias: getAlias(d[aliasKey]),
@@ -1772,7 +1772,7 @@ export class VirtualSelect {
 
     /** If searchNormalize we'll normalize the searchValue */
     let { searchValue } = this;
-    searchValue = this.searchNormalize && searchValue.trim()
+    searchValue = this.searchNormalize && searchValue.trim() !== ''
       ? Utils.normalizeString(searchValue)
       : searchValue;
     const isOptionVisible = this.isOptionVisible.bind(this);
@@ -3081,7 +3081,7 @@ export class VirtualSelect {
 
   isOptionVisible({ data, searchValue, hasExactOption, visibleOptionGroupsMapping, searchGroup, searchByStartsWith }) {
     const value = data.value.toLowerCase();
-    const label = this.searchNormalize && data.labelNormalized
+    const label = this.searchNormalize && data.labelNormalized !== undefined
       ? data.labelNormalized 
       : data.label.trim().toLowerCase();
     const { description, alias } = data;


### PR DESCRIPTION
#### What was done
- This PR aims to fix #412, where we got an error when using Virtual Select with the properties `allowNewOption: true` and `searchNormalize: true` when adding a new option.


#### Validations
- Ran regression scenarios in the documentation using the branch - ✅
- Ran additional tests at https://codepen.io/gmar/full/zxxJvaN - ✅
- Run automated tests - ✅
 
![image](https://github.com/user-attachments/assets/bafcd81b-e561-403b-87ab-181255734868)

