### PR TITLE
Fix issue where showSelectedOptionsFirst only worked the second time we opened the dropdown

### DIFF
--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -2497,6 +2497,7 @@ export class VirtualSelect {
 
     this.setSortedOptions();
     this.scrollToTop();
+    this.setVisibleOptions();
   }
 
   toggleDropbox() {


### PR DESCRIPTION
#### What was done
- This PR aims to fix #414, where using Virtual Select with the `showSelectedOptionsFirst=true`, after the selection, the dropdown was only updated properly with the selected options coming first after closing and opening it twice:

![Image](https://github.com/user-attachments/assets/853eaefc-e6fb-46f3-a89e-af6cb063161c)


#### Validations
- Ran regression scenarios in the documentation using the branch - ✅
- Ran additional tests at https://codepen.io/gmar/full/zxxJvaN - ✅
- Run automated tests - ✅

![image](https://github.com/user-attachments/assets/f7e01c68-350d-43c1-bf2b-3dc6baec051f)
