### PR TITLE
Improved label validation on isOptionVisible

### DIFF
--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -3082,9 +3082,9 @@ export class VirtualSelect {
 
   isOptionVisible({ data, searchValue, hasExactOption, visibleOptionGroupsMapping, searchGroup, searchByStartsWith }) {
     const value = data.value.toLowerCase();
-    const label = this.searchNormalize && data.labelNormalized !== undefined
+    const label = (this.searchNormalize && data.labelNormalized != null)
       ? data.labelNormalized
-      : data.label.trim().toLowerCase();
+      : (data.label || '').trim().toLowerCase();
     const { description, alias } = data;
 
     let isVisible = searchByStartsWith ? label.startsWith(searchValue) : label.includes(searchValue);


### PR DESCRIPTION
### What was done

- Improved label validation: only use labelNormalized if it exists AND is not undefined/null