### PR TITLE
fix(dropdown): Fix the focused instances when opening other dropdowns while another is opened

### DIFF
--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -538,7 +538,7 @@ export class VirtualSelect {
 
     // If clicking a different dropdown, close current one
     const clickedInstance = $clickedEle.parentElement.virtualSelect;
-    if (clickedInstance && clickedInstance !== this && this.isOpened()) {
+    if (clickedInstance && clickedInstance !== this && this.isOpened() && !this.keepAlwaysOpen) {
       // Don't focus when closing due to another dropdown being opened
       this.shouldFocusWrapperOnClose = false;
       this.closeDropbox();

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -3266,9 +3266,10 @@ export class VirtualSelect {
     // Remove from open instances
     VirtualSelect.openInstances.delete(this);
 
-    // Reset the last interacted instance
-    VirtualSelect.lastInteractedInstance = null;
-
+    // Reset the last interacted instance only if this is the last interacted instance
+    if (this === VirtualSelect.lastInteractedInstance) {
+      VirtualSelect.lastInteractedInstance = null;
+    }
     /** Remove all event listeners to prevent memory leaks and ensure proper cleanup */
     this.removeEvents();
 

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -527,13 +527,20 @@ export class VirtualSelect {
 
     // Close all if clicking outside any dropdown
     if (!$clickedEle) {
-      VirtualSelect.openInstances.forEach((instance) => instance.closeDropbox());
+      VirtualSelect.openInstances.forEach((instance) => {
+        // Don't focus when closing due to clicking outside
+        const instanceObj = instance;
+        instanceObj.shouldFocusWrapperOnClose = false;
+        instanceObj.closeDropbox();
+      });
       return;
     }
 
     // If clicking a different dropdown, close current one
     const clickedInstance = $clickedEle.parentElement.virtualSelect;
     if (clickedInstance && clickedInstance !== this && this.isOpened()) {
+      // Don't focus when closing due to another dropdown being opened
+      this.shouldFocusWrapperOnClose = false;
       this.closeDropbox();
     }
   }
@@ -1030,6 +1037,7 @@ export class VirtualSelect {
     this.halfOptionsCount = Math.ceil(this.optionsCount / 2);
     this.optionsHeight = this.getOptionsHeight();
     this.uniqueId = this.getUniqueId();
+    this.shouldFocusWrapperOnClose = true; // Initialize focus management property
   }
 
   /**
@@ -2368,6 +2376,8 @@ export class VirtualSelect {
   }
 
   openDropbox(isSilent) {
+    // Set this instance as the last interacted one immediately
+    VirtualSelect.lastInteractedInstance = this;
     let originalTransition = '';
     // Disable transitions for programmatic opening
     if (!isSilent) {
@@ -2380,7 +2390,12 @@ export class VirtualSelect {
 
     // Close all other open instances first
     VirtualSelect.openInstances.forEach((instance) => {
-      if (instance !== this) instance.closeDropbox(true); // silent close
+      if (instance !== this) {
+        // Don't focus when closing due to another dropdown being opened
+        const instanceObj = instance;
+        instanceObj.shouldFocusWrapperOnClose = false;
+        instanceObj.closeDropbox(true); // silent close
+      }
     });
 
     // Add to open instances
@@ -2498,7 +2513,11 @@ export class VirtualSelect {
       DomUtils.dispatchEvent(this.$ele, 'afterClose');
     }
 
-    this.$wrapper.focus();
+    // Only focus if this is the last interacted instance AND shouldFocusWrapperOnClose is true
+    if (this.shouldFocusWrapperOnClose && VirtualSelect.lastInteractedInstance === this && !isSilent) {
+      this.$wrapper.focus();
+    }
+    this.shouldFocusWrapperOnClose = true; // Reset for next close
 
     DomUtils.setAttr(this.$dropboxWrapper, 'tabindex', '-1');
     DomUtils.setAria(this.$dropboxWrapper, 'hidden', true);
@@ -2525,6 +2544,7 @@ export class VirtualSelect {
   }
 
   toggleDropbox() {
+    VirtualSelect.lastInteractedInstance = this;
     if (this.isOpened()) {
       this.closeDropbox();
     } else {
@@ -3246,6 +3266,9 @@ export class VirtualSelect {
     // Remove from open instances
     VirtualSelect.openInstances.delete(this);
 
+    // Reset the last interacted instance
+    VirtualSelect.lastInteractedInstance = null;
+
     /** Remove all event listeners to prevent memory leaks and ensure proper cleanup */
     this.removeEvents();
 
@@ -3562,6 +3585,9 @@ window.VirtualSelect = VirtualSelect;
 
 // Static property for tracking open dropdowns
 VirtualSelect.openInstances = new Set();
+
+// Static property for tracking the last interacted instance
+VirtualSelect.lastInteractedInstance = null;
 
 /** polyfill to fix an issue in ie browser */
 if (typeof NodeList !== 'undefined' && NodeList.prototype && !NodeList.prototype.forEach) {


### PR DESCRIPTION
#### What was happening?

- This PR aims to fix #419, where when using the open-source library Virtual Select, if we have two dropdowns, when we open dropdown A, then scroll down to dropdown B without closing dropdown A, and once we click on dropdown B to open it, dropdown A remains focused when closed. 
- This focus shouldn't exist; only the focus on dropdown B should be retained. 

#### What was done
- Added a mechanism to manage focused instances so we can make sure we only focus on the instance being clicked on.
- Can be tested [here](https://codepen.io/gmar/pen/zxGYBwO)

#### Validations
- Ran regression scenarios in the documentation using the branch - ✅
- Run automated tests - ✅
![image](https://github.com/user-attachments/assets/9a1e3b2d-b68c-47a9-8326-aeae8159b3fb)


