### PR TITLE
fix: onChange event is fired twice when select from search input

### DIFF
--- a/cypress/e2e/examples.cy.ts
+++ b/cypress/e2e/examples.cy.ts
@@ -640,7 +640,7 @@ describe('To verify that the change event is not fired twice when selecting item
   it('select 2 in row', () => {
     cy.open(selid).find('.vscomp-option').first().click();
     cy.get(`#${resid}`).should('have.text', 'value = 1; count of changes = 1');
-    cy.open(selid).search(123).find('.vscomp-option').first().click();
+    cy.open(selid).search('123').find('.vscomp-option').first().click();
     cy.get(`#${resid}`).should('have.text', 'value = 123; count of changes = 2');
   });
 

--- a/cypress/e2e/examples.cy.ts
+++ b/cypress/e2e/examples.cy.ts
@@ -1,12 +1,18 @@
 /** cSpell:ignore vscomp */
 
-describe('Open Get Started page for Dropdowns interaction test', () => {
-  const idSingle = 'single-select'
-  const idMultiple = 'multiple-select'
+// // // // //
+// // // // // Get started page
+// // // // //
 
+describe('Open page', () => {
   it('opened', () => {
     cy.visit('get-started');
   });
+});
+
+describe('Open Get Started page for Dropdowns interaction test', () => {
+  const idSingle = 'single-select'
+  const idMultiple = 'multiple-select'
 
   it('open the single-select dropdown', () => {
     cy.open(idSingle);
@@ -27,10 +33,6 @@ describe('Open Get Started page for Dropdowns interaction test', () => {
 describe('Open Get Started page for Dropdowns interaction test clicking outside', () => {
   const idSingle = 'single-select'
   const idMultiple = 'multiple-select'
-
-  it('opened', () => {
-    cy.visit('get-started');
-  });
 
   it('open the single-select dropdown', () => {
     cy.open(idSingle);
@@ -54,7 +56,13 @@ describe('Open Get Started page for Dropdowns interaction test clicking outside'
 
 });
 
-describe('Open examples page', () => {
+
+
+// // // // //
+// // // // // Examples page
+// // // // //
+
+describe('Open page', () => {
   it('opened', () => {
     cy.visit('examples');
   });
@@ -628,13 +636,23 @@ describe('Validation', () => {
 });
 
 
-describe('To verify that the change event is not fired twice when selecting items via the search input', () => {
 
+// // // // //
+// // // // // Event page
+// // // // //
+
+describe('Open page', () => {
+  it('opened', () => {
+    cy.visit('events');
+  });
+});
+
+describe('To verify that the change event is not fired twice when selecting items via the search input', () => {
   const selid = 'select-onchange';
   const resid = 'select-onchange-results';
 
   it('go to section', () => {
-    cy.goToSection('Add Events');
+    cy.goToSection('On change');
   });
 
   it('select 2 in row', () => {

--- a/cypress/e2e/examples.cy.ts
+++ b/cypress/e2e/examples.cy.ts
@@ -626,3 +626,22 @@ describe('Validation', () => {
     cy.getVs(id).find('.vscomp-ele-wrapper').should('not.have.class', 'has-error');
   });
 });
+
+
+describe('To verify that the change event is no fired twice when selecting items via the search input', () => {
+
+  const selid = 'select-onchange';
+  const resid = 'select-onchange-results';
+
+  it('go to section', () => {
+    cy.goToSection('Add Events');
+  });
+
+  it('select 2 in row', () => {
+    cy.open(selid).find('.vscomp-option').first().click();
+    cy.get(`#${resid}`).should('have.text', 'value = 1; count of changes = 1');
+    cy.open(selid).search(123).find('.vscomp-option').first().click();
+    cy.get(`#${resid}`).should('have.text', 'value = 123; count of changes = 2');
+  });
+
+});

--- a/cypress/e2e/examples.cy.ts
+++ b/cypress/e2e/examples.cy.ts
@@ -628,7 +628,7 @@ describe('Validation', () => {
 });
 
 
-describe('To verify that the change event is no fired twice when selecting items via the search input', () => {
+describe('To verify that the change event is not fired twice when selecting items via the search input', () => {
 
   const selid = 'select-onchange';
   const resid = 'select-onchange-results';

--- a/docs/assets/script.js
+++ b/docs/assets/script.js
@@ -151,6 +151,23 @@ function initPageGetStarted() {
 }
 
 // eslint-disable-next-line no-unused-vars
+function initPageEvents() {
+
+  initVirtualSelect({
+    ele: '#select-onchange',
+    search: true,
+    dropboxWrapper: 'self', // needed for onchange unit tests
+  });
+  window.onchangeCount=0;
+  document.querySelector('#select-onchange').addEventListener('change', function() {
+    window.onchangeCount++;
+    document.querySelector('#select-onchange-results').innerText = `value = ${this.value}; count of changes = ${window.onchangeCount}`;
+  });
+
+}
+
+
+// eslint-disable-next-line no-unused-vars
 function initPageExamples() {
   initVirtualSelect({
     ele: '#single-select',
@@ -360,17 +377,6 @@ function initPageExamples() {
     additionalDropboxClasses: 'custom-dropbox',
     additionalDropboxContainerClasses: 'custom-dropbox-container',
     additionalToggleButtonClasses: 'custom-toggle-button',
-  });
-
-  initVirtualSelect({
-    ele: '#select-onchange',
-    search: true,
-    dropboxWrapper: 'self', // needed for onchange unit tests
-  });
-  window.onchangeCount=0;
-  document.querySelector('#select-onchange').addEventListener('change', function() {
-    window.onchangeCount++;
-    document.querySelector('#select-onchange-results').innerText = `value = ${this.value}; count of changes = ${window.onchangeCount}`;
   });
 
 }

--- a/docs/assets/script.js
+++ b/docs/assets/script.js
@@ -361,4 +361,16 @@ function initPageExamples() {
     additionalDropboxContainerClasses: 'custom-dropbox-container',
     additionalToggleButtonClasses: 'custom-toggle-button',
   });
+
+  initVirtualSelect({
+    ele: '#select-onchange',
+    search: true,
+    dropboxWrapper: 'self', // needed for onchange unit tests
+  });
+  window.onchangeCount=0;
+  document.querySelector('#select-onchange').addEventListener('change', function() {
+    window.onchangeCount++;
+    document.querySelector('#select-onchange-results').innerText = `value = ${this.value}; count of changes = ${window.onchangeCount}`;
+  });
+
 }

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -137,6 +137,11 @@ section.cover {
   margin-bottom: 20px;
 }
 
+#select-onchange-results {
+  padding:10px;
+  color:green;
+}
+
 /* utility classes - start */
 
 .custom-wrapper {

--- a/docs/events.md
+++ b/docs/events.md
@@ -4,15 +4,23 @@
 
 Change event would be trigged on choosing option
 
+<div id="select-onchange"></div>
+<div id="select-onchange-results"></div>
+
 ```js
+initVirtualSelect({
+  ele: '#select-onchange',
+  ...
+});
+
 /** in vanilla javascript */
-document.querySelector('#sample-select').addEventListener('change', function() {
-  console.log(this.value);
+document.querySelector('#select-onchange').addEventListener('change', function() {
+  document.querySelector('#select-onchange-results').innerText = `value = ${this.value}`;
 });
 
 /** in jquery */
-$('#sample-select').change(function() {
-  console.log(this.value);
+$('#select-onchange').change(function() {
+  $('#select-onchange-results').innerText = `value = ${this.value}`;
 });
 ```
 
@@ -39,3 +47,11 @@ document.querySelector('#sample-select').addEventListener('reset', callbackFunct
 /** in jquery */
 $('#sample-select').on('reset', callbackFunction);
 ```
+
+
+<!-- END -->
+<script>
+  setTimeout(function() {
+    initPageEvents();
+  }, 0);
+</script>

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -26,6 +26,7 @@
 - [Disable/Enable](#disable-enable)
 - [Validation](#validation)
 - [Custom styling](#custom-styling)
+- [Add Events](#add-events)
 
 ## Default dropdown
 
@@ -408,6 +409,7 @@ document.querySelector('#sample-form').addEventListener('submit', function() {
   }
 });
 ```
+
 ## Custom styling
 
 Use `additionalClasses`, `additionalDropboxClasses`, `additionalDropboxContainerClasses` and `additionalToggleButtonClasses` to customize the styling of your dropdown
@@ -423,6 +425,22 @@ VirtualSelect.init({
   additionalToggleButtonClasses: 'custom-toggle-button',
 });
 ```
+
+## Add Events
+
+<div id="select-onchange"></div>
+<div id="select-onchange-results" style="color:green;padding:10px;"></div>
+
+```js
+  initVirtualSelect({
+    ele: '#select-onchange',
+    ...
+  });
+  document.querySelector('#select-onchange').addEventListener('change', function() {
+    document.querySelector('#select-onchange-results').innerText = `value = ${this.value}`;
+  });
+```
+
 
 <script>
   setTimeout(function() {

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -26,7 +26,6 @@
 - [Disable/Enable](#disable-enable)
 - [Validation](#validation)
 - [Custom styling](#custom-styling)
-- [Add Events](#add-events)
 
 ## Default dropdown
 
@@ -426,22 +425,8 @@ VirtualSelect.init({
 });
 ```
 
-## Add Events
 
-<div id="select-onchange"></div>
-<div id="select-onchange-results"></div>
-
-```js
-  initVirtualSelect({
-    ele: '#select-onchange',
-    ...
-  });
-  document.querySelector('#select-onchange').addEventListener('change', function() {
-    document.querySelector('#select-onchange-results').innerText = `value = ${this.value}`;
-  });
-```
-
-
+<!-- END -->
 <script>
   setTimeout(function() {
     initPageExamples();

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -429,7 +429,7 @@ VirtualSelect.init({
 ## Add Events
 
 <div id="select-onchange"></div>
-<div id="select-onchange-results" style="color:green;padding:10px;"></div>
+<div id="select-onchange-results"></div>
 
 ```js
   initVirtualSelect({

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -448,8 +448,7 @@ export class VirtualSelect {
     this.$toggleAllCheckbox = this.$dropboxContainer.querySelector('.vscomp-toggle-all-checkbox');
 
     this.addEvent(this.$searchInput, 'input', 'onSearch');
-    // Now preventing "change" event bubbling from search input box
-    // that cause double trigger the main onChange handler when set by the user.
+    // Prevents the change event from bubbling and triggering the main onChange handler twice.
     this.addEvent(this.$searchInput, 'change', 'preventPropagation');
     this.addEvent(this.$searchClear, 'click keydown', 'onSearchClear');
     this.addEvent(this.$toggleAllButton, 'click', 'onToggleAllOptions');

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -448,6 +448,9 @@ export class VirtualSelect {
     this.$toggleAllCheckbox = this.$dropboxContainer.querySelector('.vscomp-toggle-all-checkbox');
 
     this.addEvent(this.$searchInput, 'input', 'onSearch');
+    // Now preventing "change" event bubbling from search input box
+    // that cause double trigger the main onChange handler when set by the user.
+    this.addEvent(this.$searchInput, 'change', 'preventPropagation');
     this.addEvent(this.$searchClear, 'click keydown', 'onSearchClear');
     this.addEvent(this.$toggleAllButton, 'click', 'onToggleAllOptions');
     this.addEvent(this.$dropboxContainerBottom, 'focus', 'onDropboxContainerTopOrBottomFocus');
@@ -694,6 +697,10 @@ export class VirtualSelect {
   onSearch(e) {
     e.stopPropagation();
     this.setSearchValue(e.target.value, true);
+  }
+
+  preventPropagation(e) {
+    e.stopPropagation();
   }
 
   onSearchClear(e) {


### PR DESCRIPTION
when search is enabled, when we enter something to select, the change event is triggered when focus is lost (for example, when clicking on the option itself) and bubble on the main onchange handler of the entire element, which causes unnecessary triggering. 
We just put an explicit handler on the input field to prevent this.

Fixes #293