### PR TITLE
fix(dropdown): Improved accessibility so navigation between items don't work while input search is focused

### DIFF
--- a/cypress/e2e/examples.cy.ts
+++ b/cypress/e2e/examples.cy.ts
@@ -4,7 +4,7 @@
 // // // // // Get started page
 // // // // //
 
-describe('Open page', () => {
+describe('Open Get started page', () => {
   it('opened', () => {
     cy.visit('get-started');
   });
@@ -58,11 +58,147 @@ describe('Open Get Started page for Dropdowns interaction test clicking outside'
 
 
 
+/**
+ * Arrow key behavior tests for search input
+ * Tests the fix that allows normal cursor movement in search input
+ * while preserving option navigation when focus moves away from search
+ */
+
+describe('Arrow key behavior in search input - cursor movement', () => {
+  const idMultiple = 'multiple-select'
+
+  it('should allow cursor movement to beginning with up arrow in search input', () => {
+    cy.open(idMultiple);
+    // Type some text in search input
+    cy.getVs(idMultiple).typeValue('ption 9', true);
+    // Press Up arrow - should move cursor to beginning
+    cy.getVs(idMultiple).pressKeys('ArrowUp');
+    // Type 'O' at cursor position (should be at beginning)
+    cy.getVs(idMultiple).typeValue('O');
+    // Verify the text has 'O' at the beginning
+    cy.getVs(idMultiple).checkOptionLabelExists('Option 9');
+  });
+
+  it('should allow cursor movement to end with down arrow in search input', () => {
+    // Clear and test Down arrow - use actual dropdown data
+    cy.getVs(idMultiple).typeValue('Option 1', true);
+    // Press Down arrow - should move cursor to end
+    cy.getVs(idMultiple).pressKeys('ArrowDown');
+    // Type '0' at cursor position (should be at end, making "Option 10")
+    cy.getVs(idMultiple).typeValue('0');
+    // Verify the text has '0' at the end
+    cy.getVs(idMultiple).checkOptionLabelExists('Option 10');
+  });
+
+  it('should allow left and right arrow keys for cursor movement in search', () => {
+    // Clear and type new text using actual dropdown data
+    cy.getVs(idMultiple).typeValue('Option 55', true);
+    // Move cursor left twice (to position before '5')
+    cy.getVs(idMultiple).pressKeys(['ArrowLeft', 'ArrowLeft']);
+    // Type 'X' in middle (before the '5')
+    cy.getVs(idMultiple).typeValue('4');
+    // Should have 'Option 455'
+    cy.getVs(idMultiple).checkOptionLabelExists('Option 455');
+    // Move cursor right twice (to end)
+    cy.getVs(idMultiple).pressKeys(['ArrowRight', 'ArrowRight']);
+    // Type 'Y' at end
+    cy.getVs(idMultiple).typeValue('6');
+    // Should have 'Option 4556'
+    cy.getVs(idMultiple).checkOptionLabelExists('Option 4556');
+  });
+
+  it('should close multiple-select dropdown', () => {
+    cy.get('body').click(10, 10); // Click outside to close
+    cy.getVs(idMultiple).find('.vscomp-ele-wrapper').should('have.class', 'closed');
+  });
+});
+
+describe('Arrow key behavior - no option navigation when search input focused', () => {
+  const idMultiple = 'multiple-select'
+  const searchInputSelector = '.vscomp-search-input';
+
+  it('should not navigate options when arrow keys used in search input', () => {
+    cy.open(idMultiple);
+    // Type in search input - use text that will filter to a few options
+    cy.getVs(idMultiple).typeValue('Option 1', true);
+    // Wait for filtering to complete
+    cy.wait(100);
+    // Verify search input is focused
+    cy.checkActiveElementHasClass('vscomp-search-input');
+    // Press Down arrow while focused on search input
+    cy.getVs(idMultiple).pressKeys('ArrowDown');
+    // Search input should still be focused (arrow key should move cursor, not navigate options)
+    cy.checkActiveElementHasClass('vscomp-search-input');
+    // Press Up arrow while focused on search input
+    cy.getVs(idMultiple).pressKeys('ArrowUp');
+    // Search input should still be focused
+    cy.checkActiveElementHasClass('vscomp-search-input');
+  });
+
+  it('should close multiple-select dropdown', () => {
+    cy.get('body').click(10, 10); // Click outside to close
+    cy.getVs(idMultiple).find('.vscomp-ele-wrapper').should('have.class', 'closed');
+  });
+});
+
+describe('Arrow key behavior - Home and End keys in search input', () => {
+  const idMultiple = 'multiple-select'
+
+  it('should work correctly with Home and End keys in search input', () => {
+    cy.open(idMultiple);
+    // Type some text using search to ensure dropdown is properly opened
+    cy.getVs(idMultiple).typeValue('ption 55', true);
+    // Press Home to go to beginning
+    cy.getVs(idMultiple).pressKeys('Home');
+    // Type at beginning
+    cy.getVs(idMultiple).typeValue('O');
+    // Should have 'Option 55'
+    cy.getVs(idMultiple).checkOptionLabelExists('Option 55');
+    // Press End to go to end
+    cy.getVs(idMultiple).pressKeys('End');
+    // Type at end
+    cy.getVs(idMultiple).typeValue('6');
+    // Should have 'Option 556'
+    cy.getVs(idMultiple).checkOptionLabelExists('Option 556');
+    cy.getVs(idMultiple).searchClear();
+  });
+
+  it('should close multiple-select dropdown', () => {
+    cy.get('body').click(10, 10); // Click outside to close
+    cy.getVs(idMultiple).find('.vscomp-ele-wrapper').should('have.class', 'closed');
+  });
+});
+
+describe('Arrow key behavior - focus management and accessibility', () => {
+  const idMultiple = 'multiple-select'
+
+  it('should allow normal text editing with arrow keys in search', () => {
+    cy.open(idMultiple);
+    // Clear and test more text editing using realistic data
+    cy.getVs(idMultiple).typeValue('tion 123', true);
+    // Use Up arrow to go to beginning
+    cy.getVs(idMultiple).pressKeys('ArrowUp');
+    cy.getVs(idMultiple).typeValue('Op');
+    cy.getVs(idMultiple).checkOptionLabelExists('Option 123');
+    // Use Down arrow to go to end
+    cy.getVs(idMultiple).pressKeys('ArrowDown');
+    cy.getVs(idMultiple).typeValue('44');
+    cy.getVs(idMultiple).checkOptionLabelExists('Option 12344');
+  });
+
+  it('should close multiple-select dropdown', () => {
+    cy.get('body').click(10, 10); // Click outside to close
+    cy.getVs(idMultiple).find('.vscomp-ele-wrapper').should('have.class', 'closed');
+  });
+});
+
+
+
 // // // // //
 // // // // // Examples page
 // // // // //
 
-describe('Open page', () => {
+describe('Open Examples page', () => {
   it('opened', () => {
     cy.visit('examples');
   });

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -69,6 +69,19 @@ declare namespace Cypress {
 
     /**
      * @example
+     * cy.checkOptionLabelExists('Option 2')
+     * cy.checkOptionLabelExists(['Option 2', 'Option 3'])
+     */
+    checkOptionLabelExists(label: string | number | (string | number)[]): Chainable<any>;
+
+    /**
+     * @example
+     * cy.checkActiveElementHasClass('vscomp-search-input')
+     */
+    checkActiveElementHasClass(className: string): Chainable<Subject>;
+
+    /**
+     * @example
      * cy.hasValueText('Option 2')
      */
     hasValueText(valueText: string): Chainable<any>;
@@ -84,6 +97,20 @@ declare namespace Cypress {
      * cy.search('Option 2')
      */
     search(value: string): Chainable<any>;
+
+    /**
+     * @example
+     * cy.typeValue('Option 2')
+     * cy.typeValue('Option 2', true)
+     */
+    typeValue(value: string, clearText?: boolean): Chainable<any>;
+
+    /**
+     * @example
+     * cy.pressKeys('Enter')
+     * cy.pressKeys(['ArrowDown', 'Enter'])
+     */
+    pressKeys(keys: string | string[]): Chainable<Subject>;
 
     /**
      * @example

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "virtual-select-plugin",
-  "version": "1.0.48",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "virtual-select-plugin",
-      "version": "1.0.48",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "tooltip-plugin": "^1.0.16"
@@ -18,6 +18,7 @@
         "babel-loader": "^9.2.1",
         "css-loader": "^6.11.0",
         "cypress": "^13.17.0",
+        "cypress-real-events": "^1.14.0",
         "docsify-cli": "^4.4.4",
         "eslint": "^8.57.1",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -3521,9 +3522,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001707",
-      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-      "integrity": "sha1-xeEE0Znm9DVaiY/NmVoGbH65v0E=",
+      "version": "1.0.30001731",
+      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
+      "integrity": "sha1-J3wHQW6kYT7FZOWw/7R+e2DzLi8=",
       "dev": true,
       "funding": [
         {
@@ -4246,6 +4247,16 @@
       },
       "engines": {
         "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/cypress-real-events": {
+      "version": "1.14.0",
+      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/cypress-real-events/-/cypress-real-events-1.14.0.tgz",
+      "integrity": "sha1-xUldtQor0kf0rM3pg69xU1ZpRdM=",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x || ^14.x"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -14705,9 +14716,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001707",
-      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-      "integrity": "sha1-xeEE0Znm9DVaiY/NmVoGbH65v0E=",
+      "version": "1.0.30001731",
+      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
+      "integrity": "sha1-J3wHQW6kYT7FZOWw/7R+e2DzLi8=",
       "dev": true
     },
     "caseless": {
@@ -15379,6 +15390,13 @@
           "dev": true
         }
       }
+    },
+    "cypress-real-events": {
+      "version": "1.14.0",
+      "resolved": "https://pkgs.dev.azure.com/OutSystemsRD/_packaging/ArtifactRepository/npm/registry/cypress-real-events/-/cypress-real-events-1.14.0.tgz",
+      "integrity": "sha1-xUldtQor0kf0rM3pg69xU1ZpRdM=",
+      "dev": true,
+      "requires": {}
     },
     "dashdash": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-loader": "^9.2.1",
     "css-loader": "^6.11.0",
     "cypress": "^13.17.0",
+    "cypress-real-events": "^1.14.0",
     "docsify-cli": "^4.4.4",
     "eslint": "^8.57.1",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -590,6 +590,10 @@ export class VirtualSelect {
   }
 
   onDownArrowPress(e) {
+    // Allow default behavior (cursor movement) when search input is focused
+    if (document.activeElement === this.$searchInput) {
+      return;
+    }
     e.preventDefault();
 
     if (this.isOpened()) {
@@ -600,6 +604,10 @@ export class VirtualSelect {
   }
 
   onUpArrowPress(e) {
+    // Allow default behavior (cursor movement) when search input is focused
+    if (document.activeElement === this.$searchInput) {
+      return;
+    }
     e.preventDefault();
 
     if (this.isOpened()) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "checkJs": true,
     "strict": true,
     "declaration": true,
-    "types": ["cypress"],
+    "types": ["cypress", "node", "cypress-real-events"],
     "emitDeclarationOnly": true
   },
 


### PR DESCRIPTION
#### What was happening?

- This PR aims to fix #432, where when using a dropdown with search, when we were focused on the input search, the arrow down and arrow up keys were being used to navigate through the list options, and this was blocking a normal behavior of an input (that is, moving the cursor to the start/end of the string).

#### What was done
- Added a mechanism to move the cursor to the start/end of the string when focused on the input search and, when using the keyboard keys (arrow up, arrow down, Home and End)
- Added regression tests.

#### Validations
- Ran regression scenarios in the documentation using the branch - ✅
- Run automated tests - ✅
<img width="921" height="637" alt="image" src="https://github.com/user-attachments/assets/8e4c5099-6d41-4e75-b8a4-3c9a89c07479" />
