### PR TITLE
fix(dropdown): Fixed Dropdown with values as tags getting TAB navigation focus trapped

### DIFF
--- a/src/virtual-select.js
+++ b/src/virtual-select.js
@@ -648,8 +648,11 @@ export class VirtualSelect {
 
   onToggleButtonPress(e) {
     if (e.type === 'keydown') {
+      // Allow default Tab navigation and other non-activation keys
+      if (e.code !== 'Enter' && e.code !== 'Space') {
+        return;
+      }
       e.preventDefault();
-      if (e.code !== 'Enter' && e.code !== 'Space') return;
     }
 
     const $target = e.target;


### PR DESCRIPTION
#### What was happening?

- This PR aims to fix #440, where when the Dropdown with values as tags was focused on TAB navigation, we couldn't move to another element since it got focus trapped.

#### What was done
- Previously, we called `e.preventDefault()` for ANY keydown on the toggle button, and that suppressed the browser's native Tab / Shift+Tab behavior and effectively trapped focus inside the component when `showValueAsTags` is enabled (tags live inside the toggle button), because Tab could never advance to the next element. 
- We now only prevent default for activation keys (Enter / Space), so normal keyboard navigation (Tab, Shift+Tab, Arrow keys, etc.) works.

### Testing
- To test the use can you can add the following CSS class to make it easier to see:
```css
.markdown-section :focus{
  outline: 2px solid #ffcf00;     
  outline-offset: 1px;
  border-radius: 3px; 
}
``` 
- Select some values on the show values as tags
- Navigate using TAB and notice that now we don't get focus trapped in the clear button from the tag:
![Issue440](https://github.com/user-attachments/assets/b0916c5a-f42f-45b7-b8a9-c5a7eedd07e6)

#### Validations
- Ran regression scenarios in the documentation using the branch - ✅
- Run automated tests - ✅
<img width="907" height="367" alt="image" src="https://github.com/user-attachments/assets/7db4f13b-84f3-45cf-967c-53dd9f128a73" />




